### PR TITLE
Use String as Key

### DIFF
--- a/QacheeProject/Qachee/build.gradle
+++ b/QacheeProject/Qachee/build.gradle
@@ -3,10 +3,10 @@ apply plugin: 'maven'
 
 android {
     compileSdkVersion 21
-    buildToolsVersion "21.1.1"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
-        minSdkVersion 7
+        minSdkVersion 4
         targetSdkVersion 21
         versionCode 2
         versionName "1.1"
@@ -14,13 +14,12 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:appcompat-v7:21.0.+'
+    compile 'com.android.support:support-v4:21.0.3'
 }
 
 //group 'com.qachee'
 //archivesBaseName = 'qachee'
 //version '1.0'
-
 
 //ext.home = "file://" + System.getProperty("user.home") + "/.m2/repository"
 //

--- a/QacheeProject/Qachee/src/main/java/com/qachee/ExpirationTime.java
+++ b/QacheeProject/Qachee/src/main/java/com/qachee/ExpirationTime.java
@@ -1,25 +1,25 @@
 package com.qachee;
 
+import android.support.annotation.IntDef;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
 /**
- * Enum class that is used to set the Expiration Time policy in Qachee.
+ * Class that is used to set the Expiration Time policy in Qachee.
  */
-public enum ExpirationTime {
+public final class ExpirationTime {
 
-	TEN_SECONDS(10000),
-	THIRTY_SECONDS(30000),
-	ONE_MINUTE(60000),
-	TWO_MINUTES(120000),
-	TEN_MINUTES(600000),
-	TWENTY_MINUTES(1200000);
-
-	private long time;
-
-	private ExpirationTime(long time) {
-		this.time = time;
+	@Retention(RetentionPolicy.SOURCE)
+	@IntDef({TEN_SECONDS, THIRTY_SECONDS, ONE_MINUTE, TWO_MINUTES, TEN_MINUTES, TWENTY_MINUTES})
+	public @interface ExpirationPolicy {
 	}
 
-	public long getValue() {
-		return this.time;
-	}
+	public static final long TEN_SECONDS = 10000;
+	public static final long THIRTY_SECONDS = 30000;
+	public static final long ONE_MINUTE = 60000;
+	public static final long TWO_MINUTES = 120000;
+	public static final long TEN_MINUTES = 600000;
+	public static final long TWENTY_MINUTES = 1200000;
 
 }

--- a/QacheeProject/Qachee/src/main/java/com/qachee/Qacheeable.java
+++ b/QacheeProject/Qachee/src/main/java/com/qachee/Qacheeable.java
@@ -9,13 +9,15 @@ public interface Qacheeable {
 	 * Returns the key value that will be the key that reference the value.
 	 * Typically you will use the "id" of the Database but you can also use
 	 * the hashcode value.
+	 *
 	 * @return the key
 	 */
-	Long getKey();
+	String getKey();
 
 
 	/**
 	 * Returns the last updated time in milliseconds.
+	 *
 	 * @return The last updated time in milliseconds.
 	 */
 	long lastUpdate();

--- a/QacheeProject/Qachee/src/main/java/com/qachee/QacheeableObject.java
+++ b/QacheeProject/Qachee/src/main/java/com/qachee/QacheeableObject.java
@@ -2,7 +2,7 @@ package com.qachee;
 
 
 /**
- * This abstract class is the responsable to check and update the last updated time. Typically POJOs
+ * This abstract class is the responsible to check and update the last updated time. Typically POJOs
  * should be subclasses of QacheeableObject.
  */
 public abstract class QacheeableObject implements Qacheeable {
@@ -19,7 +19,6 @@ public abstract class QacheeableObject implements Qacheeable {
 		update();
 		return result;
 	}
-
 
 	@Override
 	public void update() {

--- a/QacheeProject/QacheeSample/build.gradle
+++ b/QacheeProject/QacheeSample/build.gradle
@@ -1,8 +1,8 @@
-apply plugin: 'android'
+apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 21
-    buildToolsVersion "21.1.1"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 8

--- a/QacheeProject/QacheeSample/src/main/java/com/qachee/sample/adapter/CharacterAdapter.java
+++ b/QacheeProject/QacheeSample/src/main/java/com/qachee/sample/adapter/CharacterAdapter.java
@@ -34,7 +34,7 @@ public class CharacterAdapter extends BaseAdapter {
 
 	@Override
 	public long getItemId(int i) {
-		return this.list.get(i).getKey();
+		return i;
 	}
 
 	@Override
@@ -43,9 +43,9 @@ public class CharacterAdapter extends BaseAdapter {
 		CharacterItemView itemView;
 		Character character = QacheeManager.getInstance().get(getItem(position), Character.class, false);
 
-		if(convertView != null) {
-			itemView = (CharacterItemView)convertView;
-		}else {
+		if (convertView != null) {
+			itemView = (CharacterItemView) convertView;
+		} else {
 			itemView = new CharacterItemView(parent.getContext());
 		}
 

--- a/QacheeProject/QacheeSample/src/main/java/com/qachee/sample/domain/Character.java
+++ b/QacheeProject/QacheeSample/src/main/java/com/qachee/sample/domain/Character.java
@@ -13,7 +13,7 @@ public class Character extends QacheeableObject {
 	private String description;
 	private int imageResId;
 
-	public Character(){
+	public Character() {
 		super();
 	}
 
@@ -48,9 +48,9 @@ public class Character extends QacheeableObject {
 	}
 
 	@Override
-	public Long getKey() {
-		Log.i("HASHCHODE", "KEY VALUE FOR " + getName() + "= " + hashCode());
-		return (long)hashCode();
+	public String getKey() {
+		Log.i("HASHCHODE", "KEY VALUE FOR " + getName() + "= " + getClass().getSimpleName() + hashCode());
+		return getClass().getSimpleName() + hashCode();
 	}
 
 }

--- a/QacheeProject/QacheeSample/src/main/java/com/qachee/sample/fragment/CharacterEditFragment.java
+++ b/QacheeProject/QacheeSample/src/main/java/com/qachee/sample/fragment/CharacterEditFragment.java
@@ -2,6 +2,7 @@ package com.qachee.sample.fragment;
 
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
+import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -16,12 +17,12 @@ import com.qachee.sample.domain.Character;
 /**
  * Created by nicolas on 2/17/14.
  */
-public class CharacterEditFragment extends Fragment{
+public class CharacterEditFragment extends Fragment {
 
 	private EditText editName, editDescription;
 	private Button saveButton;
 
-	private long currentSelectedCharacter;
+	private String currentSelectedCharacter;
 	public static final String CURRENT_SELECTED_CHARACTER = "current_selected_character";
 
 
@@ -29,9 +30,9 @@ public class CharacterEditFragment extends Fragment{
 		return new CharacterEditFragment();
 	}
 
-	public static Fragment newInstance(long currentSelectedCharacter) {
+	public static Fragment newInstance(String currentSelectedCharacter) {
 		Bundle b = new Bundle();
-		b.putLong(CURRENT_SELECTED_CHARACTER, currentSelectedCharacter);
+		b.putString(CURRENT_SELECTED_CHARACTER, currentSelectedCharacter);
 
 		Fragment f = new CharacterEditFragment();
 		f.setArguments(b);
@@ -64,11 +65,11 @@ public class CharacterEditFragment extends Fragment{
 
 	private void loadData() {
 
-		if(getArguments() != null && getArguments().getLong(CURRENT_SELECTED_CHARACTER) != 0) {
-			currentSelectedCharacter = getArguments().getLong(CURRENT_SELECTED_CHARACTER);
+		if (getArguments() != null && !TextUtils.isEmpty(getArguments().getString(CURRENT_SELECTED_CHARACTER))) {
+			currentSelectedCharacter = getArguments().getString(CURRENT_SELECTED_CHARACTER);
 
 			Character character = QacheeManager.getInstance().get(currentSelectedCharacter, Character.class, false);
-			if(character != null) {
+			if (character != null) {
 				editName.setText(character.getName());
 				editDescription.setText(character.getDescription());
 			}
@@ -76,10 +77,10 @@ public class CharacterEditFragment extends Fragment{
 	}
 
 	private void saveData() {
-		if(currentSelectedCharacter != 0) {
+		if (!TextUtils.isEmpty(currentSelectedCharacter)) {
 			Character character = QacheeManager.getInstance().get(currentSelectedCharacter, Character.class, false);
 
-			if(character != null) {
+			if (character != null) {
 				character.setName(editName.getText().toString());
 				character.setDescription(editDescription.getText().toString());
 				Toast.makeText(getActivity(), R.string.successfully_updated, Toast.LENGTH_SHORT).show();

--- a/QacheeProject/QacheeSample/src/main/java/com/qachee/sample/fragment/CharacterListFragment.java
+++ b/QacheeProject/QacheeSample/src/main/java/com/qachee/sample/fragment/CharacterListFragment.java
@@ -54,9 +54,9 @@ public class CharacterListFragment extends Fragment implements AdapterView.OnIte
 	private void loadList() {
 		List<Character> list = QacheeManager.getInstance().toArray(Character.class);
 
-		if(list == null || list.isEmpty()) {
+		if (list == null || list.isEmpty()) {
 			new DemoTask(getActivity()).execute();
-		}else {
+		} else {
 			adapter = new CharacterAdapter(list);
 			listView.setAdapter(adapter);
 		}
@@ -72,7 +72,7 @@ public class CharacterListFragment extends Fragment implements AdapterView.OnIte
 
 
 		// OR...
-//		long selectedItemKey = ((Character) QacheeManager.getInstance().get(selectedCharacter, false)).getKey();
+//		String selectedItemKey = ((Character) QacheeManager.getInstance().get(selectedCharacter, false)).getKey();
 //		replace(getActivity(), CharacterEditFragment.newInstance(selectedItemKey);
 	}
 
@@ -101,7 +101,7 @@ public class CharacterListFragment extends Fragment implements AdapterView.OnIte
 		@Override
 		protected void onPreExecute() throws Exception {
 			super.onPreExecute();
-			dialog = ProgressDialog.show(context, "", context.getString(R.string.loading_data) );
+			dialog = ProgressDialog.show(context, "", context.getString(R.string.loading_data));
 		}
 
 		@Override
@@ -125,10 +125,6 @@ public class CharacterListFragment extends Fragment implements AdapterView.OnIte
 			dialog.dismiss();
 		}
 	}
-
-
-
-
 
 
 }

--- a/QacheeProject/build.gradle
+++ b/QacheeProject/build.gradle
@@ -2,15 +2,15 @@
 
 buildscript {
     repositories {
-        mavenCentral()
+        jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.14.+'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 
 allprojects {
     repositories {
-        mavenCentral()
+        jcenter()
     }
 }

--- a/QacheeProject/gradle/wrapper/gradle-wrapper.properties
+++ b/QacheeProject/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Nov 21 16:18:50 GMT-03:00 2014
+#Thu Jan 08 08:06:18 MYT 2015
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip


### PR DESCRIPTION
Notable changes:
-key is now `String` instead of `long`
-added a method to resize Qachee
-support v4 annotations
-minSdkVersion=4 instead of 7
-use v4 instead of v7-appcompat in library module

Misc.
-use static final instead of enum (https://developer.android.com/training/articles/memory.html#Overhead)
-updated sample code
-formatting 
